### PR TITLE
Add multiple files and local imports

### DIFF
--- a/ballot.sol.js
+++ b/ballot.sol.js
@@ -24,7 +24,13 @@
 
 var multi = function(func) { return func.toString().match(/[^]*\/\*([^]*)\*\/\}$/)[1]; }
 
-var BALLOT_EXAMPLE = multi(function(){/*contract Ballot {
+var BALLOT_EXAMPLE = multi(function(){/*
+
+// create a new file called 'test' :)
+import "test";
+
+contract Ballot {
+
     struct Voter {
         uint weight;
         bool voted;

--- a/ballot.sol.js
+++ b/ballot.sol.js
@@ -24,12 +24,7 @@
 
 var multi = function(func) { return func.toString().match(/[^]*\/\*([^]*)\*\/\}$/)[1]; }
 
-var BALLOT_EXAMPLE = multi(function(){/*
-
-// create a new file called 'test' :)
-import "test";
-
-contract Ballot {
+var BALLOT_EXAMPLE = multi(function(){/*contract Ballot {
 
     struct Voter {
         uint weight;

--- a/index.html
+++ b/index.html
@@ -113,10 +113,10 @@ THE SOFTWARE.
 	var $filesEl = $('#files');
 
 	$filesEl.on('click','.newFile', function() {
-		var files = getFiles()
-		while (typeof files[SOL_CACHE_UNTITLED + untitledCount] !== 'undefined') untitledCount++;
+		while (window.localStorage[SOL_CACHE_UNTITLED + untitledCount])
+			untitledCount++;
 		SOL_CACHE_FILE = SOL_CACHE_UNTITLED + untitledCount;
-		window.localStorage[fileKey(SOL_CACHE_FILE)] = '';
+		window.localStorage[SOL_CACHE_FILE] = '';
 		updateFiles();
 	})
 
@@ -142,9 +142,9 @@ THE SOFTWARE.
 			$fileNameInputEl.off('keyup');
 
 			if (newName !== originalName && confirm("Are you sure you want to rename: " + originalName + " to " + newName + '?')) {
-				var content = window.localStorage.removeItem( fileKey(originalName) );
+				var content = window.localStorage.getItem( fileKey(originalName) );
 				window.localStorage[fileKey( newName )] = content;
-				window.localStorage.removeItem( fileKey(originalName) );
+				window.localStorage.removeItem( fileKey( originalName) );
 				SOL_CACHE_FILE = fileKey( newName );
 			}
 

--- a/index.html
+++ b/index.html
@@ -82,50 +82,41 @@ THE SOFTWARE.
 
 	// ----------------- editor ----------------------
 
-	var SOL_CACHE_FILE = "Untitled"
-	var SOL_CACHE_FILES_KEY = "sol-cache-files";
+	var SOL_CACHE_FILE_PREFIX = 'sol-cache-file-';
+	var SOL_CACHE_UNTITLED = SOL_CACHE_FILE_PREFIX + 'Untitled';
+	var SOL_CACHE_FILE = null;
 
 	var editor = ace.edit("input");
 	var session = editor.getSession();
 	var Range = ace.require('ace/range').Range;
 	var errMarkerId = null;
 
-	var solFiles = JSON.parse(window.localStorage.getItem(SOL_CACHE_FILES_KEY)) || [SOL_CACHE_FILE];
-	if (solFiles.length === 0) solFiles = [SOL_CACHE_FILE];
-	var solCache = window.localStorage.getItem(SOL_CACHE_FILE) || BALLOT_EXAMPLE;
-	window.localStorage.setItem(SOL_CACHE_FILE, solCache)
-
-	if (window.localStorage.getItem('sol-cache')) {
+	var untitledCount = 1;
+	if (!getFiles().length || window.localStorage['sol-cache']) {
 		// Backwards-compatibility
-		var count = '';
-		while (window.localStorage.getItem('Untitled' + count))
-			count = (count - 0) + 1;
-		window.localStorage.setItem('Untitled' + count, window.localStorage.getItem('sol-cache'));
+		while (window.localStorage[SOL_CACHE_UNTITLED + untitledCount])
+			untitledCount++;
+		SOL_CACHE_FILE = SOL_CACHE_UNTITLED + untitledCount;
+		window.localStorage[SOL_CACHE_FILE] = window.localStorage['sol-cache'] || BALLOT_EXAMPLE;
 		window.localStorage.removeItem('sol-cache');
-		solFiles.push('Untitled' + count);
 	}
 
-	window.localStorage.setItem(SOL_CACHE_FILES_KEY, JSON.stringify(solFiles));
+	SOL_CACHE_FILE = getFiles()[0];
 
-	editor.setValue(solCache, -1);
-
-
+	editor.setValue( window.localStorage[SOL_CACHE_FILE], -1);
 	session.setMode("ace/mode/javascript");
 	session.setTabSize(4);
 	session.setUseSoftTabs(true);
 
 	// ----------------- file selector-------------
 
-	var count = 0;
 	var $filesEl = $('#files');
 
 	$filesEl.on('click','.newFile', function() {
-		count++;
-		var name = 'Unititled' + count;
-		solFiles.push(name);
-		SOL_CACHE_FILE = name;
-		window.localStorage.setItem(SOL_CACHE_FILES_KEY, JSON.stringify(solFiles));
-		window.localStorage.setItem(SOL_CACHE_FILE, '');
+		var files = getFiles()
+		while (typeof files[SOL_CACHE_UNTITLED + untitledCount] !== 'undefined') untitledCount++;
+		SOL_CACHE_FILE = SOL_CACHE_UNTITLED + untitledCount;
+		window.localStorage[fileKey(SOL_CACHE_FILE)] = '';
 		updateFiles();
 	})
 
@@ -139,7 +130,7 @@ THE SOFTWARE.
 		var $fileNameInputEl = $('<input value="'+originalName+'"/>');
 		$fileTabEl.html($fileNameInputEl);
 		$fileNameInputEl.focus();
-		$fileNameInputEl.select();
+		$fileNameInputEl.select();	
 		$fileNameInputEl.on('blur', handleRename);
 		$fileNameInputEl.keyup(handleRename);
 
@@ -151,12 +142,10 @@ THE SOFTWARE.
 			$fileNameInputEl.off('keyup');
 
 			if (newName !== originalName && confirm("Are you sure you want to rename: " + originalName + " to " + newName + '?')) {
-
-				solFiles.splice(solFiles.indexOf(originalName), 1, newName);
-				window.localStorage.setItem(newName, window.localStorage.getItem(originalName));
-				window.localStorage.setItem(SOL_CACHE_FILES_KEY, JSON.stringify(solFiles));
-				window.localStorage.removeItem(originalName);
-				SOL_CACHE_FILE = newName;
+				var content = window.localStorage.removeItem( fileKey(originalName) );
+				window.localStorage[fileKey( newName )] = content;
+				window.localStorage.removeItem( fileKey(originalName) );
+				SOL_CACHE_FILE = fileKey( newName );
 			}
 
 			updateFiles();
@@ -169,13 +158,11 @@ THE SOFTWARE.
 	$filesEl.on('click', '.file .remove', function(ev) {
 		ev.preventDefault();
 		var name = $(this).parent().find('.name').text();
+		var index = getFiles().indexOf( fileKey(name) );
 
 		if (confirm("Are you sure you want to remove: " + name + " from local storage?")) {
-			var index = solFiles.indexOf(name);
-			solFiles.splice(index, 1);
-			window.localStorage.setItem(SOL_CACHE_FILES_KEY, JSON.stringify(solFiles));
-			SOL_CACHE_FILE = solFiles[ Math.max(0, index - 1)];
-			window.localStorage.removeItem(name);
+			SOL_CACHE_FILE = getFiles()[ Math.max(0, index - 1)];
+			window.localStorage.removeItem( fileKey( name ) );
 			updateFiles();
 		}
 		return false;
@@ -183,31 +170,52 @@ THE SOFTWARE.
 
 	function showFileHandler(ev) {
 		ev.preventDefault();
-		SOL_CACHE_FILE = $(this).find('.name').text();
+		SOL_CACHE_FILE = fileKey( $(this).find('.name').text() );
 		updateFiles();
 		return false;
 	}
 
-	function fileTabFromName(name) {
+	function fileTabFromKey(key) {
+		var name = fileNameFromKey(key);
 		return $('#files .file').filter(function(){ return $(this).find('.name').text() == name; });
 	}
 
+
 	function updateFiles() {
 		$filesEl.find('.file').remove();
-		for (var f in solFiles) {
-			if (solFiles[f]) $filesEl.append(fileTabTemplate(solFiles[f]));
+		var files = getFiles();
+		for (var f in files) {
+			$filesEl.append(fileTabTemplate(files[f]));
 		}
-		var active = fileTabFromName(SOL_CACHE_FILE);
+		var active = fileTabFromKey(SOL_CACHE_FILE);
 		active.addClass('active');
-		editor.setValue(window.localStorage.getItem(SOL_CACHE_FILE) || '', -1);
-		$('#input').toggle(typeof SOL_CACHE_FILE === 'string');
+		editor.setValue( window.localStorage[SOL_CACHE_FILE] || '', -1);
+		$('#input').toggle( true );
 	}
 
-	function fileTabTemplate(name) {
+	function fileTabTemplate(key) {
+		var name = fileNameFromKey(key);
 		return $('<span class="file"><span class="name">'+name+'</span><span class="remove">x</span></span>');
 	}
 
-	SOL_CACHE_FILE = solFiles[0];
+	function fileKey( name ) {
+		return SOL_CACHE_FILE_PREFIX + name;
+	}
+
+	function fileNameFromKey(key) {
+		return key.replace( SOL_CACHE_FILE_PREFIX, '' );
+	}
+
+	function getFiles() {
+		var files = [];
+		for (var f in localStorage ) {
+			if (f.indexOf( SOL_CACHE_FILE_PREFIX, 0 ) === 0) {
+				files.push(f);
+			}
+		}
+		return files;
+	}
+
 	updateFiles();
 
 		// ----------------- version selector-------------

--- a/index.html
+++ b/index.html
@@ -80,12 +80,12 @@ THE SOFTWARE.
     <script>
 
 
-        // ----------------- editor ----------------------
+	// ----------------- editor ----------------------
 
-	var SOL_CACHE_FILE = "Untitled.sol"
+	var SOL_CACHE_FILE = "Untitled"
 	var SOL_CACHE_FILES_KEY = "sol-cache-files";
 
-        var editor = ace.edit("input");
+	var editor = ace.edit("input");
         var session = editor.getSession();
         var Range = ace.require('ace/range').Range;
         var errMarkerId = null;
@@ -286,9 +286,11 @@ THE SOFTWARE.
             editor.getSession().removeMarker(errMarkerId);
             $('#output').empty();
             var input = editor.getValue();
+	    var inputIncludingImports = includeLocalImports( input );
+	    console.log( inputIncludingImports )
             var optimize = document.querySelector('#optimize').checked;
             try {
-                var data = $.parseJSON(compileJSON(input, optimize ? 1 : 0));
+		var data = $.parseJSON(compileJSON(inputIncludingImports, optimize ? 1 : 0));
             } catch (exception) {
                 renderError("Uncaught JavaScript Exception:\n" + exception);
                 return;
@@ -321,8 +323,25 @@ THE SOFTWARE.
             compileJSON = Module.cwrap("compileJSON", "string", ["string", "number"]);
             $('#version').text(Module.cwrap("version", "string", [])());
             previousInput = '';
-        onChange();
+	    onChange();
         };
+
+	function includeLocalImports( input ) {
+	    var importRegex = /import\s[\'\"]([^\'\"]+)[\'\"]/g
+	    var imports = [];
+	    var matches = [];
+	    var match;
+	    while ((match = importRegex.exec(input)) !== null) {
+		console.log("match:", match[0])
+		if (match[1] && solFiles.indexOf(match[1]) !== -1) {
+		    imports.push( match[1] )
+		    matches.push( match[0] )
+		}
+	    }
+	    for (var i in imports) { input = input.replace( matches[i], window.localStorage.getItem( imports[i] ) ); }
+	    return input;
+	}
+
         if (Module)
             onCompilerLoaded();
 

--- a/index.html
+++ b/index.html
@@ -285,12 +285,11 @@ THE SOFTWARE.
             editor.getSession().clearAnnotations();
             sourceAnnotations = [];
             editor.getSession().removeMarker(errMarkerId);
-            $('#output').empty();
-            var input = editor.getValue();
+	    $('#output').empty();
+	    var input = editor.getValue();
 	    var inputIncludingImports = includeLocalImports( input );
-	    console.log( inputIncludingImports )
-            var optimize = document.querySelector('#optimize').checked;
-            try {
+	    var optimize = document.querySelector('#optimize').checked;
+	    try {
 		var data = $.parseJSON(compileJSON(inputIncludingImports, optimize ? 1 : 0));
             } catch (exception) {
                 renderError("Uncaught JavaScript Exception:\n" + exception);
@@ -325,15 +324,14 @@ THE SOFTWARE.
             $('#version').text(Module.cwrap("version", "string", [])());
             previousInput = '';
 	    onChange();
-        };
+	};
 
 	function includeLocalImports( input ) {
-	    var importRegex = /import\s[\'\"]([^\'\"]+)[\'\"]/g
+	    var importRegex = /import\s[\'\"]([^\'\"]+)[\'\"];/g
 	    var imports = [];
 	    var matches = [];
 	    var match;
 	    while ((match = importRegex.exec(input)) !== null) {
-		console.log("match:", match[0])
 		if (match[1] && solFiles.indexOf(match[1]) !== -1) {
 		    imports.push( match[1] )
 		    matches.push( match[0] )

--- a/index.html
+++ b/index.html
@@ -132,22 +132,24 @@ THE SOFTWARE.
 	$filesEl.on( 'click','.file:not(.active)',  showFileHandler )
 
 	$filesEl.on( 'click','.file.active', function(ev){
-		var $fileTabEl = $(this)
-		var originalName = $fileTabEl.find('.name').text()
-		ev.preventDefault()
+		var $fileTabEl = $(this);
+		var originalName = $fileTabEl.find('.name').text();
+		ev.preventDefault();
 		if ($(this).find('input').length > 0 ) return false;
 		var $fileNameInputEl = $('<input value="'+originalName+'"/>');
-		$fileTabEl.html( $fileNameInputEl )
-		$fileNameInputEl.focus()
-		$fileNameInputEl.select()
-		$fileNameInputEl.on( 'blur', handleRename )
+		$fileTabEl.html( $fileNameInputEl );
+		$fileNameInputEl.focus();
+		$fileNameInputEl.select();
+		$fileNameInputEl.on( 'blur', handleRename );
 		$fileNameInputEl.keyup( handleRename );
 
 		function handleRename (ev) {
-			ev.preventDefault()
+			ev.preventDefault();
 			if (ev.which && ev.which !== 13) return false;
 			var newName = ev.target.value;
-			var $new = null
+			$fileNameInputEl.off('blur');
+			$fileNameInputEl.off('keyup');
+
 			if ( newName !== originalName && confirm( "Are you sure you want to rename: " + originalName + " to " + newName + '?' )) {
 
 				solFiles.splice( solFiles.indexOf(originalName), 1, newName );

--- a/index.html
+++ b/index.html
@@ -91,11 +91,11 @@ THE SOFTWARE.
 	var Range = ace.require('ace/range').Range;
 	var errMarkerId = null;
 
-	var untitledCount = 1;
+	var untitledCount = '';
 	if (!getFiles().length || window.localStorage['sol-cache']) {
-		// Backwards-compatibility
+		// Backwards-compatibility     
 		while (window.localStorage[SOL_CACHE_UNTITLED + untitledCount])
-			untitledCount++;
+			untitledCount = (untitledCount - 0) + 1;
 		SOL_CACHE_FILE = SOL_CACHE_UNTITLED + untitledCount;
 		window.localStorage[SOL_CACHE_FILE] = window.localStorage['sol-cache'] || BALLOT_EXAMPLE;
 		window.localStorage.removeItem('sol-cache');
@@ -114,7 +114,7 @@ THE SOFTWARE.
 
 	$filesEl.on('click','.newFile', function() {
 		while (window.localStorage[SOL_CACHE_UNTITLED + untitledCount])
-			untitledCount++;
+			untitledCount = (untitledCount - 0) + 1;
 		SOL_CACHE_FILE = SOL_CACHE_UNTITLED + untitledCount;
 		window.localStorage[SOL_CACHE_FILE] = '';
 		updateFiles();

--- a/index.html
+++ b/index.html
@@ -339,7 +339,10 @@ THE SOFTWARE.
 		    matches.push( match[0] )
 		}
 	    }
-	    for (var i in imports) { input = input.replace( matches[i], window.localStorage.getItem( imports[i] ) ); }
+	    for (var i in imports) {
+		imported = includeLocalImports( window.localStorage.getItem( imports[i] ) )
+		input = input.replace( matches[i], imported );
+	    }
 	    return input;
 	}
 

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@ THE SOFTWARE.
 
 	window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
 
-	editor.setValue( solCache, 1 );
+	editor.setValue( solCache, -1 );
 
 
 	session.setMode("ace/mode/javascript");
@@ -197,7 +197,7 @@ THE SOFTWARE.
 		}
 		var active = fileTabFromName(SOL_CACHE_FILE);
 		active.addClass('active')
-		editor.setValue( window.localStorage.getItem( SOL_CACHE_FILE ) || '', 1 );
+		editor.setValue( window.localStorage.getItem( SOL_CACHE_FILE ) || '', -1 );
 		$('#input').toggle( typeof SOL_CACHE_FILE === 'string' )
 	}
 

--- a/index.html
+++ b/index.html
@@ -128,6 +128,7 @@ THE SOFTWARE.
 		var $fileNameInputEl = $('<input value="'+originalName+'"/>');
 		$fileTabEl.html( $fileNameInputEl )
 		$fileNameInputEl.focus()
+		$fileNameInputEl.select()
 		$fileNameInputEl.on( 'blur', handleRename )
 		$fileNameInputEl.keyup( handleRename );
 

--- a/index.html
+++ b/index.html
@@ -90,10 +90,10 @@ THE SOFTWARE.
 	var Range = ace.require('ace/range').Range;
 	var errMarkerId = null;
 
-	var solFiles = JSON.parse( window.localStorage.getItem( SOL_CACHE_FILES_KEY ) ) || [SOL_CACHE_FILE];
+	var solFiles = JSON.parse(window.localStorage.getItem(SOL_CACHE_FILES_KEY)) || [SOL_CACHE_FILE];
 	if (solFiles.length === 0) solFiles = [SOL_CACHE_FILE];
-	var solCache = window.localStorage.getItem( SOL_CACHE_FILE ) || BALLOT_EXAMPLE;
-	window.localStorage.setItem( SOL_CACHE_FILE, solCache )
+	var solCache = window.localStorage.getItem(SOL_CACHE_FILE) || BALLOT_EXAMPLE;
+	window.localStorage.setItem(SOL_CACHE_FILE, solCache)
 
 	if (window.localStorage.getItem('sol-cache')) {
 		// Backwards-compatibility
@@ -105,109 +105,109 @@ THE SOFTWARE.
 		solFiles.push('Untitled' + count);
 	}
 
-	window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
+	window.localStorage.setItem(SOL_CACHE_FILES_KEY, JSON.stringify(solFiles));
 
-	editor.setValue( solCache, -1 );
+	editor.setValue(solCache, -1);
 
 
 	session.setMode("ace/mode/javascript");
-		session.setTabSize(4);
-		session.setUseSoftTabs(true);
+	session.setTabSize(4);
+	session.setUseSoftTabs(true);
 
 	// ----------------- file selector-------------
 
 	var count = 0;
 	var $filesEl = $('#files');
 
-	$filesEl.on( 'click','.newFile', function(){
+	$filesEl.on('click','.newFile', function() {
 		count++;
-		var name = 'Unititled'+count;
-		solFiles.push( name )
+		var name = 'Unititled' + count;
+		solFiles.push(name);
 		SOL_CACHE_FILE = name;
-		window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
-		window.localStorage.setItem( SOL_CACHE_FILE, '' );
+		window.localStorage.setItem(SOL_CACHE_FILES_KEY, JSON.stringify(solFiles));
+		window.localStorage.setItem(SOL_CACHE_FILE, '');
 		updateFiles();
 	})
 
-	$filesEl.on( 'click','.file:not(.active)',  showFileHandler )
+	$filesEl.on('click', '.file:not(.active)', showFileHandler);
 
-	$filesEl.on( 'click','.file.active', function(ev){
+	$filesEl.on('click', '.file.active', function(ev) {
 		var $fileTabEl = $(this);
 		var originalName = $fileTabEl.find('.name').text();
 		ev.preventDefault();
-		if ($(this).find('input').length > 0 ) return false;
+		if ($(this).find('input').length > 0) return false;
 		var $fileNameInputEl = $('<input value="'+originalName+'"/>');
-		$fileTabEl.html( $fileNameInputEl );
+		$fileTabEl.html($fileNameInputEl);
 		$fileNameInputEl.focus();
 		$fileNameInputEl.select();
-		$fileNameInputEl.on( 'blur', handleRename );
-		$fileNameInputEl.keyup( handleRename );
+		$fileNameInputEl.on('blur', handleRename);
+		$fileNameInputEl.keyup(handleRename);
 
-		function handleRename (ev) {
+		function handleRename(ev) {
 			ev.preventDefault();
 			if (ev.which && ev.which !== 13) return false;
 			var newName = ev.target.value;
 			$fileNameInputEl.off('blur');
 			$fileNameInputEl.off('keyup');
 
-			if ( newName !== originalName && confirm( "Are you sure you want to rename: " + originalName + " to " + newName + '?' )) {
+			if (newName !== originalName && confirm("Are you sure you want to rename: " + originalName + " to " + newName + '?')) {
 
-				solFiles.splice( solFiles.indexOf(originalName), 1, newName );
-				window.localStorage.setItem( newName, window.localStorage.getItem(originalName) );
-				window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
-				window.localStorage.removeItem( originalName )
+				solFiles.splice(solFiles.indexOf(originalName), 1, newName);
+				window.localStorage.setItem(newName, window.localStorage.getItem(originalName));
+				window.localStorage.setItem(SOL_CACHE_FILES_KEY, JSON.stringify(solFiles));
+				window.localStorage.removeItem(originalName);
 				SOL_CACHE_FILE = newName;
 			}
 
-			updateFiles()
+			updateFiles();
 			return false;
 		}
 
 		return false;
 	})
 
-	$filesEl.on( 'click','.file .remove', function(ev){
+	$filesEl.on('click', '.file .remove', function(ev) {
 		ev.preventDefault();
-		var name = $(this).parent().find('.name').text()
+		var name = $(this).parent().find('.name').text();
 
-		if (confirm( "Are you sure you want to remove: " + name + " from local storage?" )) {
+		if (confirm("Are you sure you want to remove: " + name + " from local storage?")) {
 			var index = solFiles.indexOf(name);
-			solFiles.splice(index, 1 );
-			window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
-			SOL_CACHE_FILE = solFiles[ Math.max(0, index - 1)]
-			window.localStorage.removeItem( name )
-			updateFiles()
+			solFiles.splice(index, 1);
+			window.localStorage.setItem(SOL_CACHE_FILES_KEY, JSON.stringify(solFiles));
+			SOL_CACHE_FILE = solFiles[ Math.max(0, index - 1)];
+			window.localStorage.removeItem(name);
+			updateFiles();
 		}
 		return false;
 	});
 
-	function showFileHandler (ev) {
-		ev.preventDefault()
+	function showFileHandler(ev) {
+		ev.preventDefault();
 		SOL_CACHE_FILE = $(this).find('.name').text();
-		updateFiles()
+		(updateFiles();
 		return false;
 	}
 
 	function fileTabFromName(name) {
-		return $('#files .file').filter(function(){ return $(this).find('.name').text() == name; })
+		return $('#files .file').filter(function(){ return $(this).find('.name').text() == name; });
 	}
 
-	function updateFiles () {
-		$filesEl.find('.file').remove()
+	function updateFiles() {
+		$filesEl.find('.file').remove();
 		for (var f in solFiles) {
-			if (solFiles[f]) $filesEl.append( fileTabTemplate(solFiles[f]) );
+			if (solFiles[f]) $filesEl.append(fileTabTemplate(solFiles[f]));
 		}
 		var active = fileTabFromName(SOL_CACHE_FILE);
-		active.addClass('active')
-		editor.setValue( window.localStorage.getItem( SOL_CACHE_FILE ) || '', -1 );
-		$('#input').toggle( typeof SOL_CACHE_FILE === 'string' )
+		active.addClass('active');
+		editor.setValue(window.localStorage.getItem(SOL_CACHE_FILE) || '', -1);
+		$('#input').toggle(typeof SOL_CACHE_FILE === 'string');
 	}
 
-	function fileTabTemplate(name){
+	function fileTabTemplate(name) {
 		return $('<span class="file"><span class="name">'+name+'</span><span class="remove">x</span></span>');
 	}
 
-	SOL_CACHE_FILE = solFiles[0]
+	SOL_CACHE_FILE = solFiles[0];
 	updateFiles();
 
 		// ----------------- version selector-------------
@@ -246,7 +246,7 @@ THE SOFTWARE.
 			}).prependTo('body');
 
 			$(document).mousemove(function(e){
-			  ghostbar.css("left",e.pageX+2);
+				ghostbar.css("left",e.pageX+2);
 			});
 		});
 
@@ -258,20 +258,20 @@ THE SOFTWARE.
 			onResize();
 		}
 
-	   $(document).mouseup(function(e){
-		   if (dragging) {
+		$(document).mouseup(function(e){
+			if (dragging) {
 				var delta = $body.width() - e.pageX+2;
 				$('#ghostbar').remove();
 				$(document).unbind('mousemove');
 				dragging = false;
-				setEditorSize( delta )
-				window.localStorage.setItem( EDITOR_SIZE_CACHE_KEY, delta );
-		   }
+				setEditorSize(delta)
+				window.localStorage.setItem(EDITOR_SIZE_CACHE_KEY, delta);
+			}
 		});
 
 		// set cached defaults
-		var cachedSize = window.localStorage.getItem( EDITOR_SIZE_CACHE_KEY );
-		if (cachedSize) setEditorSize( cachedSize );
+		var cachedSize = window.localStorage.getItem(EDITOR_SIZE_CACHE_KEY);
+		if (cachedSize) setEditorSize(cachedSize);
 		
 
 		// ----------------- editor resize ---------------
@@ -291,7 +291,7 @@ THE SOFTWARE.
 		window.onresize = onResize;
 		onResize();
 
-		document.querySelector('#editor').addEventListener('change', onResize );
+		document.querySelector('#editor').addEventListener('change', onResize);
 		
 
 		// ----------------- compiler ----------------------
@@ -306,9 +306,9 @@ THE SOFTWARE.
 			editor.getSession().removeMarker(errMarkerId);
 			$('#output').empty();
 			var input = editor.getValue();
-			window.localStorage.setItem( SOL_CACHE_FILE, input );
+			window.localStorage.setItem(SOL_CACHE_FILE, input);
 
-			var inputIncludingImports = includeLocalImports( input );
+			var inputIncludingImports = includeLocalImports(input);
 			var optimize = document.querySelector('#optimize').checked;
 			
 			try {
@@ -332,7 +332,7 @@ THE SOFTWARE.
 		var onChange = function() {
 			var input = editor.getValue();
 			if (input === "") {
-				window.localStorage.setItem( SOL_CACHE_FILE, '' )
+				window.localStorage.setItem(SOL_CACHE_FILE, '')
 				return;
 			}
 			if (input === previousInput)
@@ -349,20 +349,20 @@ THE SOFTWARE.
 		onChange();
 	};
 
-	function includeLocalImports( input ) {
+	function includeLocalImports(input) {
 		var importRegex = /import\s[\'\"]([^\'\"]+)[\'\"];/g
 		var imports = [];
 		var matches = [];
 		var match;
 		while ((match = importRegex.exec(input)) !== null) {
 		if (match[1] && solFiles.indexOf(match[1]) !== -1) {
-			imports.push( match[1] )
-			matches.push( match[0] )
+			imports.push(match[1])
+			matches.push(match[0])
 		}
 		}
 		for (var i in imports) {
-			imported = includeLocalImports( window.localStorage.getItem( imports[i] ) )
-			input = input.replace( matches[i], imported );
+			imported = includeLocalImports(window.localStorage.getItem(imports[i]))
+			input = input.replace(matches[i], imported);
 		}
 		return input;
 	}
@@ -382,8 +382,8 @@ THE SOFTWARE.
 				.append($('<pre class="error"></pre>').text(message));
 			var err = message.match(/^:([0-9]*):([0-9]*)/)
 			if (err && err.length) {
-				var errLine = parseInt( err[1], 10 ) - 1;
-				var errCol = err[2] ? parseInt( err[2], 10 ) : 0;
+				var errLine = parseInt(err[1], 10) - 1;
+				var errCol = err[2] ? parseInt(err[2], 10) : 0;
 				sourceAnnotations[sourceAnnotations.length] ={
 					row: errLine,
 					column: errCol,
@@ -399,14 +399,14 @@ THE SOFTWARE.
 			var funABI = getConstructorInterface($.parseJSON(interface));
 
 			$.each(funABI.inputs, function(i, inp) {
-				code += "var "+inp.name+" = /* var of type " + inp.type + " here */ ;\n";
+				code += "var " + inp.name + " = /* var of type " + inp.type + " here */ ;\n";
 			});
 
-			code += "\nvar "+contractName+"Contract = web3.eth.contract("+interface.replace("\n","")+");"
-				+"\nvar "+contractName+" = "+contractName+"Contract.new(";
+			code += "\nvar " + contractName + "Contract = web3.eth.contract(" + interface.replace("\n","") + ");"
+				+"\nvar " + contractName + " = " + contractName + "Contract.new(";
 			
 			$.each(funABI.inputs, function(i, inp) {
-				code += "\n   "+inp.name+",";
+				code += "\n   " + inp.name + ",";
 			});
 						
 			code += "\n   {"+
@@ -425,7 +425,7 @@ THE SOFTWARE.
 		};
 
 		var combined = function(contractName, interface, bytecode){
-			return JSON.stringify( [{name: contractName, interface: interface, bytecode: bytecode}]);
+			return JSON.stringify([{name: contractName, interface: interface, bytecode: bytecode}]);
 
 		};
 
@@ -437,7 +437,7 @@ THE SOFTWARE.
 				var contractOutput = $('<div class="contractOutput"/>')
 					.append(title);
 				var body = $('<div class="body" />')
-				contractOutput.append( body );
+				contractOutput.append(body);
 				if (contract.bytecode.length > 0)
 					title.append($('<div class="size"/>').text((contract.bytecode.length / 2) + ' bytes'))
 					body.append(getExecuteInterface(contract, contractName))
@@ -451,7 +451,7 @@ THE SOFTWARE.
 				title.click(function(ev){ $(this).parent().toggleClass('hide') });
 			}
 
-			$('.col2 input,textarea').click(function() { this.select(); } );
+			$('.col2 input,textarea').click(function() { this.select(); });
 		};
 		var tableRowItems = function(first, second, cls) {
 			return $('<div class="row"/>')
@@ -532,7 +532,7 @@ THE SOFTWARE.
 
 			return text;
 		};
-		$('.asmOutput button').click(function() {$(this).parent().find('pre').toggle(); } )
+		$('.asmOutput button').click(function() {$(this).parent().find('pre').toggle(); })
 
 		// ----------------- VM ----------------------
 
@@ -621,7 +621,7 @@ THE SOFTWARE.
 
 			var appendFunctions = function(address) {
 				var instance = $('<div class="contractInstance"/>');
-				var title = $('<span class="title"/>').text('Contract at ' + address.toString('hex') );
+				var title = $('<span class="title"/>').text('Contract at ' + address.toString('hex'));
 				instance.append(title);
 				$.each(abi, function(i, funABI) {
 					if (funABI.type != 'function') return;

--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@ THE SOFTWARE.
 	function showFileHandler(ev) {
 		ev.preventDefault();
 		SOL_CACHE_FILE = $(this).find('.name').text();
-		(updateFiles();
+		updateFiles();
 		return false;
 	}
 

--- a/index.html
+++ b/index.html
@@ -369,13 +369,13 @@ THE SOFTWARE.
 		var matches = [];
 		var match;
 		while ((match = importRegex.exec(input)) !== null) {
-		if (match[1] && solFiles.indexOf(match[1]) !== -1) {
+		if (match[1] && getFiles().indexOf(fileKey(match[1])) !== -1) {
 			imports.push(match[1])
 			matches.push(match[0])
 		}
 		}
 		for (var i in imports) {
-			imported = includeLocalImports(window.localStorage.getItem(imports[i]))
+			imported = includeLocalImports(window.localStorage.getItem( fileKey(imports[i]) ))
 			input = input.replace(matches[i], imported);
 		}
 		return input;

--- a/index.html
+++ b/index.html
@@ -47,37 +47,37 @@ THE SOFTWARE.
 
 </head>
 <body>
-    
+	
 
-    <div id="editor">
+	<div id="editor">
 	<div id="files">
-	    <span class="newFile" title="New File">+</span>
+		<span class="newFile" title="New File">+</span>
 	</div>
-        <div id="input"></div>
-    </div>
+		<div id="input"></div>
+	</div>
 
-    <div id="righthand-panel">
-        <div id="dragbar"></div>
-        <div id="header">
-            <img id="solIcon" src="solidity.svg">
-            <h1>Solidity realtime<br/>compiler and runtime</h1>
-            <div class="info">
-                <p>Version: <span id="version">(loading)</span><br/>
-                Change to: <select id="versionSelector"></select><br/>
-                Execution environment does not connect to any node, everyhing is local and in memory only.<br/>
-                <code>tx.origin = <span id="txorigin"/></code></p>
-            </div>
-            <div id="optimizeBox">
-                <input id="editorWrap" type="checkbox"><label for="editorWrap">Text Wrap</label>
-                <input id="optimize" type="checkbox"><label for="optimize">Enable Optimization</label>
-            </div>
-        </div>
-        <div id="output"></div>
-    </div>
+	<div id="righthand-panel">
+		<div id="dragbar"></div>
+		<div id="header">
+			<img id="solIcon" src="solidity.svg">
+			<h1>Solidity realtime<br/>compiler and runtime</h1>
+			<div class="info">
+				<p>Version: <span id="version">(loading)</span><br/>
+				Change to: <select id="versionSelector"></select><br/>
+				Execution environment does not connect to any node, everyhing is local and in memory only.<br/>
+				<code>tx.origin = <span id="txorigin"/></code></p>
+			</div>
+			<div id="optimizeBox">
+				<input id="editorWrap" type="checkbox"><label for="editorWrap">Text Wrap</label>
+				<input id="optimize" type="checkbox"><label for="optimize">Enable Optimization</label>
+			</div>
+		</div>
+		<div id="output"></div>
+	</div>
 
-    
+	
 
-    <script>
+	<script>
 
 
 	// ----------------- editor ----------------------
@@ -86,8 +86,8 @@ THE SOFTWARE.
 	var SOL_CACHE_FILES_KEY = "sol-cache-files";
 
 	var editor = ace.edit("input");
-        var session = editor.getSession();
-        var Range = ace.require('ace/range').Range;
+		var session = editor.getSession();
+		var Range = ace.require('ace/range').Range;
 	var errMarkerId = null;
 
 	var solFiles = JSON.parse( window.localStorage.getItem( SOL_CACHE_FILES_KEY ) ) || [SOL_CACHE_FILE];
@@ -100,8 +100,8 @@ THE SOFTWARE.
 
 
 	session.setMode("ace/mode/javascript");
-        session.setTabSize(4);
-        session.setUseSoftTabs(true);
+		session.setTabSize(4);
+		session.setUseSoftTabs(true);
 
 	// ----------------- file selector-------------
 
@@ -109,520 +109,524 @@ THE SOFTWARE.
 	var $filesEl = $('#files');
 
 	$filesEl.on( 'click','.newFile', function(){
-	    count++;
-	    var name = 'Unititled'+count;
-	    solFiles.push( name )
-	    SOL_CACHE_FILE = name;
-	    window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
-	    window.localStorage.setItem( SOL_CACHE_FILE, '' );
-	    updateFiles();
+		count++;
+		var name = 'Unititled'+count;
+		solFiles.push( name )
+		SOL_CACHE_FILE = name;
+		window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
+		window.localStorage.setItem( SOL_CACHE_FILE, '' );
+		updateFiles();
 	})
 
 	$filesEl.on( 'click','.file:not(.active)',  showFileHandler )
 
 	$filesEl.on( 'click','.file.active', function(ev){
-	    var $fileTabEl = $(this)
-	    var originalName = $fileTabEl.find('.name').text()
-	    ev.preventDefault()
-	    if ($(this).find('input').length > 0 ) return false;
-	    var $fileNameInputEl = $('<input value="'+originalName+'"/>');
-	    $fileTabEl.html( $fileNameInputEl )
-	    $fileNameInputEl.focus()
-
-	    $fileNameInputEl.on( 'blur', function(ev){
+		var $fileTabEl = $(this)
+		var originalName = $fileTabEl.find('.name').text()
 		ev.preventDefault()
-		var newName = ev.target.value;
-		var $new = null
-		if ( newName !== originalName && confirm( "Are you sure you want to rename: " + originalName + " to " + newName + '?' )) {
+		if ($(this).find('input').length > 0 ) return false;
+		var $fileNameInputEl = $('<input value="'+originalName+'"/>');
+		$fileTabEl.html( $fileNameInputEl )
+		$fileNameInputEl.focus()
+		$fileNameInputEl.on( 'blur', handleRename )
+		$fileNameInputEl.keyup( handleRename );
 
-		    solFiles.splice( solFiles.indexOf(originalName), 1, newName );
-		    window.localStorage.setItem( newName, window.localStorage.getItem(originalName) );
-		    window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
-		    window.localStorage.removeItem( originalName )
-		    SOL_CACHE_FILE = newName;
+		function handleRename (ev) {
+			ev.preventDefault()
+			if (ev.which && ev.which !== 13) return false;
+			var newName = ev.target.value;
+			var $new = null
+			if ( newName !== originalName && confirm( "Are you sure you want to rename: " + originalName + " to " + newName + '?' )) {
+
+				solFiles.splice( solFiles.indexOf(originalName), 1, newName );
+				window.localStorage.setItem( newName, window.localStorage.getItem(originalName) );
+				window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
+				window.localStorage.removeItem( originalName )
+				SOL_CACHE_FILE = newName;
+			}
+
+			updateFiles()
+			return false;
 		}
 
-		updateFiles()
 		return false;
-	    })
-	    return false;
 	})
 
 	$filesEl.on( 'click','.file .remove', function(ev){
-	    ev.preventDefault();
-	    var name = $(this).parent().find('.name').text()
+		ev.preventDefault();
+		var name = $(this).parent().find('.name').text()
 
-	    if (confirm( "Are you sure you want to remove: " + name + " from local storage?" )) {
-		var index = solFiles.indexOf(name);
-		solFiles.splice(index, 1 );
-		window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
-		SOL_CACHE_FILE = solFiles[ Math.max(0, index - 1)]
-		window.localStorage.removeItem( name )
-		updateFiles()
-	    }
-	    return false;
-	})
+		if (confirm( "Are you sure you want to remove: " + name + " from local storage?" )) {
+			var index = solFiles.indexOf(name);
+			solFiles.splice(index, 1 );
+			window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
+			SOL_CACHE_FILE = solFiles[ Math.max(0, index - 1)]
+			window.localStorage.removeItem( name )
+			updateFiles()
+		}
+		return false;
+	});
 
 	function showFileHandler (ev) {
-	    ev.preventDefault()
-	    SOL_CACHE_FILE = $(this).find('.name').text();
-	    updateFiles()
-	    return false;
+		ev.preventDefault()
+		SOL_CACHE_FILE = $(this).find('.name').text();
+		updateFiles()
+		return false;
 	}
 
 	function fileTabFromName(name) {
-	    return $('#files .file').filter(function(){ return $(this).find('.name').text() == name; })
+		return $('#files .file').filter(function(){ return $(this).find('.name').text() == name; })
 	}
 
 	function updateFiles () {
-	    $filesEl.find('.file').remove()
-	    for (var f in solFiles) {
-		if (solFiles[f]) $filesEl.append( fileTabTemplate(solFiles[f]) );
-	    }
-	    var active = fileTabFromName(SOL_CACHE_FILE);
-	    active.addClass('active')
-	    editor.setValue( window.localStorage.getItem( SOL_CACHE_FILE ) || '', 1 );
-	    $('#input').toggle( typeof SOL_CACHE_FILE === 'string' )
+		$filesEl.find('.file').remove()
+		for (var f in solFiles) {
+			if (solFiles[f]) $filesEl.append( fileTabTemplate(solFiles[f]) );
+		}
+		var active = fileTabFromName(SOL_CACHE_FILE);
+		active.addClass('active')
+		editor.setValue( window.localStorage.getItem( SOL_CACHE_FILE ) || '', 1 );
+		$('#input').toggle( typeof SOL_CACHE_FILE === 'string' )
 	}
 
 	function fileTabTemplate(name){
-	    return $('<span class="file"><span class="name">'+name+'</span><span class="remove">x</span></span>');
+		return $('<span class="file"><span class="name">'+name+'</span><span class="remove">x</span></span>');
 	}
 
 	SOL_CACHE_FILE = solFiles[0]
 	updateFiles();
 
-        // ----------------- version selector-------------
+		// ----------------- version selector-------------
 
-        // var soljsonSources is provided by bin/list.js
-        $('option', '#versionSelector').remove();
-        $.each(soljsonSources, function(i, file) {
-            if (file) {
-                var version = file.replace(/soljson-(.*).js/, "$1");
-                $('#versionSelector').append(new Option(version, file));
-            }
-        });
-        $('#versionSelector').change(function() {
-            Module = null;
-            compileJSON = null;
-            var script = document.createElement('script');
-            script.type = 'text/javascript';
-            script.src = 'bin/' + $('#versionSelector').val();
-            $('head').append(script);
-            onCompilerLoaded();
-        });
-        
-        // ----------------- resizeable ui ---------------
-        
-        var EDITOR_SIZE_CACHE_KEY = "editor-size-cache";
-        var dragging = false;
-        $('#dragbar').mousedown(function(e){
-            e.preventDefault();
-            dragging = true;
-            var main = $('#righthand-panel');
-            var ghostbar = $('<div id="ghostbar">', {
-                css: {
-                    top: main.offset().top,
-                    left: main.offset().left
-                }
-            }).prependTo('body');
+		// var soljsonSources is provided by bin/list.js
+		$('option', '#versionSelector').remove();
+		$.each(soljsonSources, function(i, file) {
+			if (file) {
+				var version = file.replace(/soljson-(.*).js/, "$1");
+				$('#versionSelector').append(new Option(version, file));
+			}
+		});
+		$('#versionSelector').change(function() {
+			Module = null;
+			compileJSON = null;
+			var script = document.createElement('script');
+			script.type = 'text/javascript';
+			script.src = 'bin/' + $('#versionSelector').val();
+			$('head').append(script);
+			onCompilerLoaded();
+		});
+		
+		// ----------------- resizeable ui ---------------
+		
+		var EDITOR_SIZE_CACHE_KEY = "editor-size-cache";
+		var dragging = false;
+		$('#dragbar').mousedown(function(e){
+			e.preventDefault();
+			dragging = true;
+			var main = $('#righthand-panel');
+			var ghostbar = $('<div id="ghostbar">', {
+				css: {
+					top: main.offset().top,
+					left: main.offset().left
+				}
+			}).prependTo('body');
 
-            $(document).mousemove(function(e){
-              ghostbar.css("left",e.pageX+2);
-            });
-        });
+			$(document).mousemove(function(e){
+			  ghostbar.css("left",e.pageX+2);
+			});
+		});
 
-        var $body = $('body');
+		var $body = $('body');
 
-        function setEditorSize (delta) {
-            $('#righthand-panel').css("width", delta);
-            $('#editor').css("right", delta);
-            onResize();
-        }
+		function setEditorSize (delta) {
+			$('#righthand-panel').css("width", delta);
+			$('#editor').css("right", delta);
+			onResize();
+		}
 
-       $(document).mouseup(function(e){
-           if (dragging) {
-                var delta = $body.width() - e.pageX+2;
-                $('#ghostbar').remove();
-                $(document).unbind('mousemove');
-                dragging = false;
-                setEditorSize( delta )
-                window.localStorage.setItem( EDITOR_SIZE_CACHE_KEY, delta );
-           }
-        });
+	   $(document).mouseup(function(e){
+		   if (dragging) {
+				var delta = $body.width() - e.pageX+2;
+				$('#ghostbar').remove();
+				$(document).unbind('mousemove');
+				dragging = false;
+				setEditorSize( delta )
+				window.localStorage.setItem( EDITOR_SIZE_CACHE_KEY, delta );
+		   }
+		});
 
-        // set cached defaults
-        var cachedSize = window.localStorage.getItem( EDITOR_SIZE_CACHE_KEY );
-        if (cachedSize) setEditorSize( cachedSize );
-        
+		// set cached defaults
+		var cachedSize = window.localStorage.getItem( EDITOR_SIZE_CACHE_KEY );
+		if (cachedSize) setEditorSize( cachedSize );
+		
 
-        // ----------------- editor resize ---------------
+		// ----------------- editor resize ---------------
 
-        function onResize() {
-            editor.resize();
-            session.setUseWrapMode(document.querySelector('#editorWrap').checked);
-            if(session.getUseWrapMode()) {
-                var characterWidth = editor.renderer.characterWidth;
-                var contentWidth = editor.container.ownerDocument.getElementsByClassName("ace_scroller")[0].clientWidth;
+		function onResize() {
+			editor.resize();
+			session.setUseWrapMode(document.querySelector('#editorWrap').checked);
+			if(session.getUseWrapMode()) {
+				var characterWidth = editor.renderer.characterWidth;
+				var contentWidth = editor.container.ownerDocument.getElementsByClassName("ace_scroller")[0].clientWidth;
 
-                if(contentWidth > 0) {
-                    session.setWrapLimit(parseInt(contentWidth / characterWidth, 10));
-                }
-            }
-        }
-        window.onresize = onResize;
-        onResize();
+				if(contentWidth > 0) {
+					session.setWrapLimit(parseInt(contentWidth / characterWidth, 10));
+				}
+			}
+		}
+		window.onresize = onResize;
+		onResize();
 
-        document.querySelector('#editor').addEventListener('change', onResize );
-        
+		document.querySelector('#editor').addEventListener('change', onResize );
+		
 
-        // ----------------- compiler ----------------------
-        var compileJSON;
+		// ----------------- compiler ----------------------
+		var compileJSON;
 
-        var previousInput = '';
-        var sourceAnnotations = [];
-        var compile = function() {
-            editor.getSession().clearAnnotations();
-            sourceAnnotations = [];
-            editor.getSession().removeMarker(errMarkerId);
-	    $('#output').empty();
-	    var input = editor.getValue();
-	    var inputIncludingImports = includeLocalImports( input );
-	    var optimize = document.querySelector('#optimize').checked;
-	    try {
+		var previousInput = '';
+		var sourceAnnotations = [];
+		var compile = function() {
+			editor.getSession().clearAnnotations();
+			sourceAnnotations = [];
+			editor.getSession().removeMarker(errMarkerId);
+		$('#output').empty();
+		var input = editor.getValue();
+		var inputIncludingImports = includeLocalImports( input );
+		var optimize = document.querySelector('#optimize').checked;
+		try {
 		var data = $.parseJSON(compileJSON(inputIncludingImports, optimize ? 1 : 0));
-            } catch (exception) {
-                renderError("Uncaught JavaScript Exception:\n" + exception);
-                return;
-            }
-            if (data['error'] !== undefined)
-                renderError(data['error']);
-            if (data['errors'] != undefined)
-                $.each(data['errors'], function(i, err) {
-                    renderError(err);
-                });
-            else
-                renderContracts(data, input);
-                
-        }
-        var compileTimeout = null;
-        var onChange = function() {
-            var input = editor.getValue();
-            if (input === "") {
+			} catch (exception) {
+				renderError("Uncaught JavaScript Exception:\n" + exception);
+				return;
+			}
+			if (data['error'] !== undefined)
+				renderError(data['error']);
+			if (data['errors'] != undefined)
+				$.each(data['errors'], function(i, err) {
+					renderError(err);
+				});
+			else
+				renderContracts(data, input);
+				
+		}
+		var compileTimeout = null;
+		var onChange = function() {
+			var input = editor.getValue();
+			if (input === "") {
 		window.localStorage.setItem( SOL_CACHE_FILE, '' )
-                return;
-            }
-            if (input === previousInput)
-                return;
-            previousInput = input;
-            if (compileTimeout) window.clearTimeout(compileTimeout);
-            compileTimeout = window.setTimeout(compile, 300);
-        };
+				return;
+			}
+			if (input === previousInput)
+				return;
+			previousInput = input;
+			if (compileTimeout) window.clearTimeout(compileTimeout);
+			compileTimeout = window.setTimeout(compile, 300);
+		};
 
-        var onCompilerLoaded = function() {
-            compileJSON = Module.cwrap("compileJSON", "string", ["string", "number"]);
-            $('#version').text(Module.cwrap("version", "string", [])());
-            previousInput = '';
-	    onChange();
+		var onCompilerLoaded = function() {
+			compileJSON = Module.cwrap("compileJSON", "string", ["string", "number"]);
+			$('#version').text(Module.cwrap("version", "string", [])());
+			previousInput = '';
+		onChange();
 	};
 
 	function includeLocalImports( input ) {
-	    var importRegex = /import\s[\'\"]([^\'\"]+)[\'\"];/g
-	    var imports = [];
-	    var matches = [];
-	    var match;
-	    while ((match = importRegex.exec(input)) !== null) {
+		var importRegex = /import\s[\'\"]([^\'\"]+)[\'\"];/g
+		var imports = [];
+		var matches = [];
+		var match;
+		while ((match = importRegex.exec(input)) !== null) {
 		if (match[1] && solFiles.indexOf(match[1]) !== -1) {
-		    imports.push( match[1] )
-		    matches.push( match[0] )
+			imports.push( match[1] )
+			matches.push( match[0] )
 		}
-	    }
-	    for (var i in imports) {
-		imported = includeLocalImports( window.localStorage.getItem( imports[i] ) )
-		input = input.replace( matches[i], imported );
-	    }
-	    return input;
+		}
+		for (var i in imports) {
+			imported = includeLocalImports( window.localStorage.getItem( imports[i] ) )
+			input = input.replace( matches[i], imported );
+		}
+		return input;
 	}
 
-        if (Module)
-            onCompilerLoaded();
+		if (Module)
+			onCompilerLoaded();
 
-        editor.getSession().on('change', onChange);
+		editor.getSession().on('change', onChange);
 
-        document.querySelector('#optimize').addEventListener('change', compile);
+		document.querySelector('#optimize').addEventListener('change', compile);
 
-        // ----------------- compiler output renderer ----------------------
-        var detailsOpen = {};
+		// ----------------- compiler output renderer ----------------------
+		var detailsOpen = {};
 
-        var renderError = function(message) {
-            $('#output')
-                .append($('<pre class="error"></pre>').text(message));
-            var err = message.match(/^:([0-9]*):([0-9]*)/)
-            if (err && err.length) {
-                var errLine = parseInt( err[1], 10 ) - 1;
-                var errCol = err[2] ? parseInt( err[2], 10 ) : 0;
-                sourceAnnotations[sourceAnnotations.length] ={
-                    row: errLine,
-                    column: errCol,
-                    text: message,
-                    type: "error"
-                };
-                editor.getSession().setAnnotations(sourceAnnotations);
-            }
-        };
+		var renderError = function(message) {
+			$('#output')
+				.append($('<pre class="error"></pre>').text(message));
+			var err = message.match(/^:([0-9]*):([0-9]*)/)
+			if (err && err.length) {
+				var errLine = parseInt( err[1], 10 ) - 1;
+				var errCol = err[2] ? parseInt( err[2], 10 ) : 0;
+				sourceAnnotations[sourceAnnotations.length] ={
+					row: errLine,
+					column: errCol,
+					text: message,
+					type: "error"
+				};
+				editor.getSession().setAnnotations(sourceAnnotations);
+			}
+		};
 
-        var gethDeploy = function(contractName, interface, bytecode){
-            var code = "";
-            var funABI = getConstructorInterface($.parseJSON(interface));
+		var gethDeploy = function(contractName, interface, bytecode){
+			var code = "";
+			var funABI = getConstructorInterface($.parseJSON(interface));
 
-            $.each(funABI.inputs, function(i, inp) {
-                code += "var "+inp.name+" = /* var of type " + inp.type + " here */ ;\n";
-            });
+			$.each(funABI.inputs, function(i, inp) {
+				code += "var "+inp.name+" = /* var of type " + inp.type + " here */ ;\n";
+			});
 
-            code += "\nvar "+contractName+"Contract = web3.eth.contract("+interface.replace("\n","")+");"
-                +"\nvar "+contractName+" = "+contractName+"Contract.new(";
-            
-            $.each(funABI.inputs, function(i, inp) {
-                code += "\n   "+inp.name+",";
-            });
-                        
-            code += "\n   {"+
-            "\n     from: web3.eth.accounts[0], "+
-            "\n     data: '"+bytecode+"', "+
-            "\n     gas: 1000000"+
-            "\n   }, function(e, contract){"+
-            "\n    if (typeof contract.address != 'undefined') {"+            
-            "\n         console.log(e, contract);"+
-            "\n         console.log('Contract mined! address: ' + contract.address + ' transactionHash: ' + contract.transactionHash);" +
-            "\n    }" +
-            "\n })";
+			code += "\nvar "+contractName+"Contract = web3.eth.contract("+interface.replace("\n","")+");"
+				+"\nvar "+contractName+" = "+contractName+"Contract.new(";
+			
+			$.each(funABI.inputs, function(i, inp) {
+				code += "\n   "+inp.name+",";
+			});
+						
+			code += "\n   {"+
+			"\n     from: web3.eth.accounts[0], "+
+			"\n     data: '"+bytecode+"', "+
+			"\n     gas: 1000000"+
+			"\n   }, function(e, contract){"+
+			"\n    if (typeof contract.address != 'undefined') {"+            
+			"\n         console.log(e, contract);"+
+			"\n         console.log('Contract mined! address: ' + contract.address + ' transactionHash: ' + contract.transactionHash);" +
+			"\n    }" +
+			"\n })";
 
 
-            return code;
-        };
+			return code;
+		};
 
-        var combined = function(contractName, interface, bytecode){
-            return JSON.stringify( [{name: contractName, interface: interface, bytecode: bytecode}]);
+		var combined = function(contractName, interface, bytecode){
+			return JSON.stringify( [{name: contractName, interface: interface, bytecode: bytecode}]);
 
-        };
+		};
 
-        var renderContracts = function(data, source) {
-	    window.localStorage.setItem( SOL_CACHE_FILE, source );
+		var renderContracts = function(data, source) {
+		window.localStorage.setItem( SOL_CACHE_FILE, source );
 
-            $('#output').empty();
-            for (var contractName in data.contracts) {
-                var contract = data.contracts[contractName];
-                var title = $('<h3 class="title"/>').text(contractName);
-                var contractOutput = $('<div class="contractOutput"/>')
-                    .append(title);
-                var body = $('<div class="body" />')
-                contractOutput.append( body );
-                if (contract.bytecode.length > 0)
-                    title.append($('<div class="size"/>').text((contract.bytecode.length / 2) + ' bytes'))
-                    body.append(getExecuteInterface(contract, contractName))
-                        .append(tableRow('Bytecode', contract.bytecode));
-                body.append(tableRow('Interface', contract['interface']))
-                    .append(textRow('Web3 deploy', gethDeploy(contractName.toLowerCase(),contract['interface'],contract.bytecode), 'deploy'))
-                    .append(textRow('uDApp', combined(contractName,contract['interface'],contract.bytecode), 'deploy'))
-                    .append(getDetails(contract, source, contractName));
+			$('#output').empty();
+			for (var contractName in data.contracts) {
+				var contract = data.contracts[contractName];
+				var title = $('<h3 class="title"/>').text(contractName);
+				var contractOutput = $('<div class="contractOutput"/>')
+					.append(title);
+				var body = $('<div class="body" />')
+				contractOutput.append( body );
+				if (contract.bytecode.length > 0)
+					title.append($('<div class="size"/>').text((contract.bytecode.length / 2) + ' bytes'))
+					body.append(getExecuteInterface(contract, contractName))
+						.append(tableRow('Bytecode', contract.bytecode));
+				body.append(tableRow('Interface', contract['interface']))
+					.append(textRow('Web3 deploy', gethDeploy(contractName.toLowerCase(),contract['interface'],contract.bytecode), 'deploy'))
+					.append(textRow('uDApp', combined(contractName,contract['interface'],contract.bytecode), 'deploy'))
+					.append(getDetails(contract, source, contractName));
 
-                $('#output').append(contractOutput);
-                title.click(function(ev){ $(this).parent().toggleClass('hide') });
-            }
+				$('#output').append(contractOutput);
+				title.click(function(ev){ $(this).parent().toggleClass('hide') });
+			}
 
-            $('.col2 input,textarea').click(function() { this.select(); } );
-        };
-        var tableRowItems = function(first, second, cls) {
-            return $('<div class="row"/>')
-                .addClass(cls)
-                .append($('<div class="col1">').append(first))
-                .append($('<div class="col2">').append(second));
-        };
-        var tableRow = function(description, data) {
-            return tableRowItems(
-                $('<span/>').text(description),
-                $('<input readonly="readonly"/>').val(data));
-        };
-        var textRow = function(description, data, cls) {
-            return tableRowItems(
-                $('<strong/>').text(description),
-                $('<textarea readonly="readonly" class="gethDeployText"/>').val(data),
-                cls);
-        };
-        var getDetails = function(contract, source, contractName) {
-            var button = $('<button>Details</button>');
-            var details = $('<div style="display: none;"/>')
-                .append(tableRow('Solidity Interface', contract.solidity_interface))
-                .append(tableRow('Opcodes', contract.opcodes));
-            var funHashes = '';
-            for (var fun in contract.functionHashes)
-                funHashes += contract.functionHashes[fun] + ' ' + fun + '\n';
-            details.append($('<span class="col1">Functions</span>'));
-            details.append($('<pre/>').text(funHashes));
-            details.append($('<span class="col1">Gas Estimates</span>'));
-            details.append($('<pre/>').text(formatGasEstimates(contract.gasEstimates)));
-            if (contract.runtimeBytecode && contract.runtimeBytecode.length > 0)
-                details.append(tableRow('Runtime Bytecode', contract.runtimeBytecode));
-            if (contract.assembly !== null)
-            {
-                details.append($('<span class="col1">Assembly</span>'));
-                var assembly = $('<pre/>').text(formatAssemblyText(contract.assembly, '', source));
-                details.append(assembly);
-            }
-            button.click(function() { detailsOpen[contractName] = !detailsOpen[contractName]; details.toggle(); });
-            if (detailsOpen[contractName])
-                details.show();
-            return $('<div/>').append(button).append(details);
-        };
-        var formatGasEstimates = function(data) {
-            var gasToText = function(g) { return g === null ? 'unknown' : g; }
-            var text = '';
-            if ('creation' in data)
-                text += 'Creation: ' + gasToText(data.creation[0]) + ' + ' + gasToText(data.creation[1]) + '\n';
-            text += 'External:\n';
-            for (var fun in data.external)
-                text += '  ' + fun + ': ' + gasToText(data.external[fun]) + '\n';
-            text += 'Internal:\n';
-            for (var fun in data.internal)
-                text += '  ' + fun + ': ' + gasToText(data.internal[fun]) + '\n';
-            return text;
-        };
-        var formatAssemblyText = function(asm, prefix, source) {
-            if (typeof(asm) == typeof('') || asm === null || asm === undefined)
-                return prefix + asm + '\n';
-            var text = prefix + '.code\n';
-            $.each(asm['.code'], function(i, item) {
-                var v = item.value === undefined ? '' : item.value;
-                var src = '';
-                if (item.begin !== undefined && item.end != undefined)
-                    src = source.slice(item.begin, item.end).replace('\n', '\\n', 'g');
-                if (src.length > 30)
-                    src = src.slice(0, 30) + '...';
-                if (item.name != 'tag')
-                    text += '  ';
-                text += prefix + item.name + ' ' + v + '\t\t\t' + src +  '\n';
-            });
-            text += prefix + '.data\n';
-            if (asm['.data'])
-                $.each(asm['.data'], function(i, item) {
-                    text += '  ' + prefix + '' + i + ':\n';
-                    text += formatAssemblyText(item, prefix + '    ', source);
-                });
+			$('.col2 input,textarea').click(function() { this.select(); } );
+		};
+		var tableRowItems = function(first, second, cls) {
+			return $('<div class="row"/>')
+				.addClass(cls)
+				.append($('<div class="col1">').append(first))
+				.append($('<div class="col2">').append(second));
+		};
+		var tableRow = function(description, data) {
+			return tableRowItems(
+				$('<span/>').text(description),
+				$('<input readonly="readonly"/>').val(data));
+		};
+		var textRow = function(description, data, cls) {
+			return tableRowItems(
+				$('<strong/>').text(description),
+				$('<textarea readonly="readonly" class="gethDeployText"/>').val(data),
+				cls);
+		};
+		var getDetails = function(contract, source, contractName) {
+			var button = $('<button>Details</button>');
+			var details = $('<div style="display: none;"/>')
+				.append(tableRow('Solidity Interface', contract.solidity_interface))
+				.append(tableRow('Opcodes', contract.opcodes));
+			var funHashes = '';
+			for (var fun in contract.functionHashes)
+				funHashes += contract.functionHashes[fun] + ' ' + fun + '\n';
+			details.append($('<span class="col1">Functions</span>'));
+			details.append($('<pre/>').text(funHashes));
+			details.append($('<span class="col1">Gas Estimates</span>'));
+			details.append($('<pre/>').text(formatGasEstimates(contract.gasEstimates)));
+			if (contract.runtimeBytecode && contract.runtimeBytecode.length > 0)
+				details.append(tableRow('Runtime Bytecode', contract.runtimeBytecode));
+			if (contract.assembly !== null)
+			{
+				details.append($('<span class="col1">Assembly</span>'));
+				var assembly = $('<pre/>').text(formatAssemblyText(contract.assembly, '', source));
+				details.append(assembly);
+			}
+			button.click(function() { detailsOpen[contractName] = !detailsOpen[contractName]; details.toggle(); });
+			if (detailsOpen[contractName])
+				details.show();
+			return $('<div/>').append(button).append(details);
+		};
+		var formatGasEstimates = function(data) {
+			var gasToText = function(g) { return g === null ? 'unknown' : g; }
+			var text = '';
+			if ('creation' in data)
+				text += 'Creation: ' + gasToText(data.creation[0]) + ' + ' + gasToText(data.creation[1]) + '\n';
+			text += 'External:\n';
+			for (var fun in data.external)
+				text += '  ' + fun + ': ' + gasToText(data.external[fun]) + '\n';
+			text += 'Internal:\n';
+			for (var fun in data.internal)
+				text += '  ' + fun + ': ' + gasToText(data.internal[fun]) + '\n';
+			return text;
+		};
+		var formatAssemblyText = function(asm, prefix, source) {
+			if (typeof(asm) == typeof('') || asm === null || asm === undefined)
+				return prefix + asm + '\n';
+			var text = prefix + '.code\n';
+			$.each(asm['.code'], function(i, item) {
+				var v = item.value === undefined ? '' : item.value;
+				var src = '';
+				if (item.begin !== undefined && item.end != undefined)
+					src = source.slice(item.begin, item.end).replace('\n', '\\n', 'g');
+				if (src.length > 30)
+					src = src.slice(0, 30) + '...';
+				if (item.name != 'tag')
+					text += '  ';
+				text += prefix + item.name + ' ' + v + '\t\t\t' + src +  '\n';
+			});
+			text += prefix + '.data\n';
+			if (asm['.data'])
+				$.each(asm['.data'], function(i, item) {
+					text += '  ' + prefix + '' + i + ':\n';
+					text += formatAssemblyText(item, prefix + '    ', source);
+				});
 
-            return text;
-        };
-        $('.asmOutput button').click(function() {$(this).parent().find('pre').toggle(); } )
+			return text;
+		};
+		$('.asmOutput button').click(function() {$(this).parent().find('pre').toggle(); } )
 
-        // ----------------- VM ----------------------
+		// ----------------- VM ----------------------
 
-        var stateTrie = new EthVm.Trie();
-        var vm = new EthVm.VM(stateTrie);
-        //@todo this does not calculate the gas costs correctly but gets the job done.
-        var identityCode = 'return { gasUsed: 1, return: opts.data, exception: 1 };';
-        var identityAddr = ethUtil.pad(new Buffer('04', 'hex'), 20)
-        vm.loadPrecompiled(identityAddr, identityCode);
-        var secretKey = '3cd7232cd6f3fc66a57a6bedc1a8ed6c228fff0a327e169c2bcc5e869ed49511'
-        var publicKey = '0406cc661590d48ee972944b35ad13ff03c7876eae3fd191e8a2f77311b0a3c6613407b5005e63d7d8d76b89d5f900cde691497688bb281e07a5052ff61edebdc0'
-        var address = ethUtil.pubToAddress(new Buffer(publicKey, 'hex'));
-        $('#txorigin').text('0x' + address.toString('hex'));
-        var account = new EthVm.Account();
-        account.balance = 'f00000000000000001';
-        var nonce = 0;
-        stateTrie.put(address, account.serialize());
-        var runTx = function(data, to, cb) {
-            var tx = new EthVm.Transaction({
-                nonce: new Buffer([nonce++]), //@todo count beyond 255
-                gasPrice: '01',
-                gasLimit: '3000000000', // plenty
-                to: to,
-                data: data
-            });
-            tx.sign(new Buffer(secretKey, 'hex'));
-            vm.runTx({tx: tx}, cb);
-        };
+		var stateTrie = new EthVm.Trie();
+		var vm = new EthVm.VM(stateTrie);
+		//@todo this does not calculate the gas costs correctly but gets the job done.
+		var identityCode = 'return { gasUsed: 1, return: opts.data, exception: 1 };';
+		var identityAddr = ethUtil.pad(new Buffer('04', 'hex'), 20)
+		vm.loadPrecompiled(identityAddr, identityCode);
+		var secretKey = '3cd7232cd6f3fc66a57a6bedc1a8ed6c228fff0a327e169c2bcc5e869ed49511'
+		var publicKey = '0406cc661590d48ee972944b35ad13ff03c7876eae3fd191e8a2f77311b0a3c6613407b5005e63d7d8d76b89d5f900cde691497688bb281e07a5052ff61edebdc0'
+		var address = ethUtil.pubToAddress(new Buffer(publicKey, 'hex'));
+		$('#txorigin').text('0x' + address.toString('hex'));
+		var account = new EthVm.Account();
+		account.balance = 'f00000000000000001';
+		var nonce = 0;
+		stateTrie.put(address, account.serialize());
+		var runTx = function(data, to, cb) {
+			var tx = new EthVm.Transaction({
+				nonce: new Buffer([nonce++]), //@todo count beyond 255
+				gasPrice: '01',
+				gasLimit: '3000000000', // plenty
+				to: to,
+				data: data
+			});
+			tx.sign(new Buffer(secretKey, 'hex'));
+			vm.runTx({tx: tx}, cb);
+		};
 
-        var getConstructorInterface = function(abi) {
-            var funABI = {'name':'','inputs':[],'type':'constructor','outputs':[]};
-            for (var i = 0; i < abi.length; i++)
-                if (abi[i].type == 'constructor') {
-                    funABI.inputs = abi[i].inputs || [];
-                    break;
-                }
-            return funABI;
-        };
+		var getConstructorInterface = function(abi) {
+			var funABI = {'name':'','inputs':[],'type':'constructor','outputs':[]};
+			for (var i = 0; i < abi.length; i++)
+				if (abi[i].type == 'constructor') {
+					funABI.inputs = abi[i].inputs || [];
+					break;
+				}
+			return funABI;
+		};
 
-        var getCallButton = function(args) {
-            // args.abi, args.bytecode [constr only], args.address [fun only]
-            // args.appendFunctions [constr only]
-            var isConstructor = args.bytecode !== undefined;
-            var fun = new web3.eth.function(args.abi);
-            var inputs = '';
-            $.each(args.abi.inputs, function(i, inp) {
-                if (inputs != '') inputs += ', ';
-                inputs += inp.type + ' ' + inp.name;
-            });
-            var inputField = $('<input/>').attr('placeholder', inputs);
-            var outputSpan = $('<div class="output"/>');
-            var button = $('<button/>')
-                .text(args.bytecode ? 'Create' : fun.displayName())
-                .click(function() {
-                    var funArgs = $.parseJSON('[' + inputField.val() + ']');
-                    var data = fun.toPayload(funArgs).data;
-                    if (data.slice(0, 2) == '0x') data = data.slice(2);
-                    if (isConstructor)
-                        data = args.bytecode + data.slice(8);
-                    outputSpan.text('...');
-                    runTx(data, args.address, function(err, result) {
-                        if (err)
-                            outputSpan.text(err);
-                        else if (isConstructor) {
-                            outputSpan.text(' Creation used ' + result.vm.gasUsed.toString(10) + ' gas.');
-                            args.appendFunctions(result.createdAddress);
-                        } else {
-                            var outputObj = fun.unpackOutput('0x' + result.vm.return.toString('hex'));
-                            outputSpan.text(' Returned: ' + JSON.stringify(outputObj));
-                        }
-                    });
-                });
-            if (!isConstructor)
-                button.addClass('runButton');
-            var c = $('<div class="contractProperty"/>')
-                .append(button);
-            if (args.abi.inputs.length > 0)
-                c.append(inputField);
-            return c.append(outputSpan);
-        };
+		var getCallButton = function(args) {
+			// args.abi, args.bytecode [constr only], args.address [fun only]
+			// args.appendFunctions [constr only]
+			var isConstructor = args.bytecode !== undefined;
+			var fun = new web3.eth.function(args.abi);
+			var inputs = '';
+			$.each(args.abi.inputs, function(i, inp) {
+				if (inputs != '') inputs += ', ';
+				inputs += inp.type + ' ' + inp.name;
+			});
+			var inputField = $('<input/>').attr('placeholder', inputs);
+			var outputSpan = $('<div class="output"/>');
+			var button = $('<button/>')
+				.text(args.bytecode ? 'Create' : fun.displayName())
+				.click(function() {
+					var funArgs = $.parseJSON('[' + inputField.val() + ']');
+					var data = fun.toPayload(funArgs).data;
+					if (data.slice(0, 2) == '0x') data = data.slice(2);
+					if (isConstructor)
+						data = args.bytecode + data.slice(8);
+					outputSpan.text('...');
+					runTx(data, args.address, function(err, result) {
+						if (err)
+							outputSpan.text(err);
+						else if (isConstructor) {
+							outputSpan.text(' Creation used ' + result.vm.gasUsed.toString(10) + ' gas.');
+							args.appendFunctions(result.createdAddress);
+						} else {
+							var outputObj = fun.unpackOutput('0x' + result.vm.return.toString('hex'));
+							outputSpan.text(' Returned: ' + JSON.stringify(outputObj));
+						}
+					});
+				});
+			if (!isConstructor)
+				button.addClass('runButton');
+			var c = $('<div class="contractProperty"/>')
+				.append(button);
+			if (args.abi.inputs.length > 0)
+				c.append(inputField);
+			return c.append(outputSpan);
+		};
 
-        var getExecuteInterface = function(contract, name) {
-            var abi = $.parseJSON(contract.interface);
-            var execInter = $('<div/>');
-            var funABI = getConstructorInterface(abi);
+		var getExecuteInterface = function(contract, name) {
+			var abi = $.parseJSON(contract.interface);
+			var execInter = $('<div/>');
+			var funABI = getConstructorInterface(abi);
 
-            var appendFunctions = function(address) {
-                var instance = $('<div class="contractInstance"/>');
-                var title = $('<span class="title"/>').text('Contract at ' + address.toString('hex') );
-                instance.append(title);
-                $.each(abi, function(i, funABI) {
-                    if (funABI.type != 'function') return;
-                    instance.append(getCallButton({
-                        abi: funABI,
-                        address: address
-                    }));
-                });
-                execInter.append(instance);
-                title.click(function(ev){ $(this).parent().toggleClass('hide') });
-            };
+			var appendFunctions = function(address) {
+				var instance = $('<div class="contractInstance"/>');
+				var title = $('<span class="title"/>').text('Contract at ' + address.toString('hex') );
+				instance.append(title);
+				$.each(abi, function(i, funABI) {
+					if (funABI.type != 'function') return;
+					instance.append(getCallButton({
+						abi: funABI,
+						address: address
+					}));
+				});
+				execInter.append(instance);
+				title.click(function(ev){ $(this).parent().toggleClass('hide') });
+			};
 
-            if (contract.bytecode.length > 0)
-                execInter
-                    .append(getCallButton({
-                        abi: funABI,
-                        bytecode: contract.bytecode,
-                        appendFunctions: appendFunctions
-                    }));
-            return execInter;
-        };
+			if (contract.bytecode.length > 0)
+				execInter
+					.append(getCallButton({
+						abi: funABI,
+						bytecode: contract.bytecode,
+						appendFunctions: appendFunctions
+					}));
+			return execInter;
+		};
 
-    </script>
+	</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -50,6 +50,9 @@ THE SOFTWARE.
     
 
     <div id="editor">
+	<div id="files">
+	    <span class="newFile" title="New File">+</span>
+	</div>
         <div id="input"></div>
     </div>
 
@@ -79,19 +82,118 @@ THE SOFTWARE.
 
         // ----------------- editor ----------------------
 
-        var SOL_CACHE_KEY = "sol-cache";
+	var SOL_CACHE_FILE = "Untitled.sol"
+	var SOL_CACHE_FILES_KEY = "sol-cache-files";
 
         var editor = ace.edit("input");
         var session = editor.getSession();
         var Range = ace.require('ace/range').Range;
         var errMarkerId = null;
 
-        var solCache = window.localStorage.getItem( SOL_CACHE_KEY );
+	var solFiles = JSON.parse( window.localStorage.getItem( SOL_CACHE_FILES_KEY ) ) || [SOL_CACHE_FILE];
+	window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
+
+	var solCache = window.localStorage.getItem( SOL_CACHE_FILE );
         editor.setValue( solCache || BALLOT_EXAMPLE, 1 );
+
 
         session.setMode("ace/mode/javascript");
         session.setTabSize(4);
         session.setUseSoftTabs(true);
+
+	// ----------------- file selector-------------
+
+	var count = 0;
+	var $filesEl = $('#files');
+
+	$filesEl.on( 'click','.newFile', function(){
+	    count++;
+	    var name = 'Unititled'+count+'.sol';
+	    solFiles.push( name )
+	    SOL_CACHE_FILE = name;
+	    window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
+	    window.localStorage.setItem( SOL_CACHE_FILE, '' );
+	    console.log('new file added: ', solFiles)
+	    updateFiles();
+	})
+
+	$filesEl.on( 'click','.file:not(.active)',  showFileHandler )
+
+	$filesEl.on( 'click','.file.active', function(ev){
+	    var $fileTabEl = $(this)
+	    var originalName = $fileTabEl.find('.name').text()
+	    console.log("click active: ", originalName )
+	    ev.preventDefault()
+	    if ($(this).find('input').length > 0 ) return false;
+	    var $fileNameInputEl = $('<input value="'+originalName+'"/>');
+	    $fileTabEl.html( $fileNameInputEl )
+	    $fileNameInputEl.focus()
+
+	    $fileNameInputEl.on( 'blur', function(ev){
+		ev.preventDefault()
+		var newName = ev.target.value;
+		var $new = null
+		if (confirm( "Are you sure you want to rename: " + originalName + " to " + newName + '?' )) {
+
+		    solFiles[solFiles.indexOf(originalName)] = newName
+		    window.localStorage.setItem( newName, window.localStorage.getItem(originalName) );
+		    window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
+		    window.localStorage.setItem( originalName, '')
+		    SOL_CACHE_FILE = newName;
+		    updateFiles()
+		}
+
+		fileTabFromName(newName || originalName ).addClass('active')
+		return false;
+	    })
+	    return false;
+	})
+
+	$filesEl.on( 'click','.file .remove', function(ev){
+	    ev.preventDefault();
+	    var name = $(this).parent().find('.name').text()
+
+	    if (confirm( "Are you sure you want to remove: " + name + " from local storage?" )) {
+		console.log("remove file, ", ev.target)
+		var index = solFiles.indexOf(name);
+		solFiles[index] = undefined;
+		window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
+		SOL_CACHE_FILE = solFiles[ Math.max(0, index - 1)]
+		window.localStorage.setItem( name, null)
+		updateFiles()
+	    }
+	    return false;
+	})
+
+	function showFileHandler (ev) {
+	    ev.preventDefault()
+	    SOL_CACHE_FILE = $(this).find('.name').text();
+	    console.log('click normal', SOL_CACHE_FILE, typeof window.localStorage.getItem( SOL_CACHE_FILE ))
+	    updateFiles()
+	    return false;
+	}
+
+	function fileTabFromName(name) {
+	    return $('#files .file').filter(function(){ return $(this).find('.name').text() == name; })
+	}
+
+	function updateFiles () {
+	    console.log("Update files", solFiles, SOL_CACHE_FILE, typeof window.localStorage.getItem( SOL_CACHE_FILE ) )
+	    $filesEl.find('.file').remove()
+	    for (var f in solFiles) {
+		if (solFiles[f]) $filesEl.append( fileTabTemplate(solFiles[f]) );
+	    }
+	    var active = fileTabFromName(SOL_CACHE_FILE);
+	    active.addClass('active')
+	    editor.setValue( window.localStorage.getItem( SOL_CACHE_FILE ) || '', 1 );
+	}
+
+	function fileTabTemplate(name){
+	    return $('<span class="file"><span class="name">'+name+'</span><span class="remove">x</span></span>');
+	}
+
+	SOL_CACHE_FILE = solFiles[0]
+	updateFiles();
 
         // ----------------- version selector-------------
 
@@ -209,7 +311,7 @@ THE SOFTWARE.
         var onChange = function() {
             var input = editor.getValue();
             if (input === "") {
-                window.localStorage.setItem( SOL_CACHE_KEY, '' )
+		window.localStorage.setItem( SOL_CACHE_FILE, '' )
                 return;
             }
             if (input === previousInput)
@@ -288,7 +390,7 @@ THE SOFTWARE.
         };
 
         var renderContracts = function(data, source) {
-            window.localStorage.setItem( SOL_CACHE_KEY, source );
+	    window.localStorage.setItem( SOL_CACHE_FILE, source );
 
             $('#output').empty();
             for (var contractName in data.contracts) {

--- a/index.html
+++ b/index.html
@@ -88,9 +88,10 @@ THE SOFTWARE.
 	var editor = ace.edit("input");
         var session = editor.getSession();
         var Range = ace.require('ace/range').Range;
-        var errMarkerId = null;
+	var errMarkerId = null;
 
 	var solFiles = JSON.parse( window.localStorage.getItem( SOL_CACHE_FILES_KEY ) ) || [SOL_CACHE_FILE];
+	if (solFiles.length === 0) solFiles = [SOL_CACHE_FILE];
 	window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
 
 	var solCache = window.localStorage.getItem( SOL_CACHE_FILE ) || BALLOT_EXAMPLE;
@@ -181,6 +182,7 @@ THE SOFTWARE.
 	    var active = fileTabFromName(SOL_CACHE_FILE);
 	    active.addClass('active')
 	    editor.setValue( window.localStorage.getItem( SOL_CACHE_FILE ) || '', 1 );
+	    $('#input').toggle( typeof SOL_CACHE_FILE === 'string' )
 	}
 
 	function fileTabTemplate(name){

--- a/index.html
+++ b/index.html
@@ -93,11 +93,12 @@ THE SOFTWARE.
 	var solFiles = JSON.parse( window.localStorage.getItem( SOL_CACHE_FILES_KEY ) ) || [SOL_CACHE_FILE];
 	window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
 
-	var solCache = window.localStorage.getItem( SOL_CACHE_FILE );
-        editor.setValue( solCache || BALLOT_EXAMPLE, 1 );
+	var solCache = window.localStorage.getItem( SOL_CACHE_FILE ) || BALLOT_EXAMPLE;
+	window.localStorage.setItem( SOL_CACHE_FILE, solCache )
+	editor.setValue( solCache, 1 );
 
 
-        session.setMode("ace/mode/javascript");
+	session.setMode("ace/mode/javascript");
         session.setTabSize(4);
         session.setUseSoftTabs(true);
 
@@ -113,7 +114,6 @@ THE SOFTWARE.
 	    SOL_CACHE_FILE = name;
 	    window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
 	    window.localStorage.setItem( SOL_CACHE_FILE, '' );
-	    console.log('new file added: ', solFiles)
 	    updateFiles();
 	})
 
@@ -122,7 +122,6 @@ THE SOFTWARE.
 	$filesEl.on( 'click','.file.active', function(ev){
 	    var $fileTabEl = $(this)
 	    var originalName = $fileTabEl.find('.name').text()
-	    console.log("click active: ", originalName )
 	    ev.preventDefault()
 	    if ($(this).find('input').length > 0 ) return false;
 	    var $fileNameInputEl = $('<input value="'+originalName+'"/>');
@@ -135,10 +134,10 @@ THE SOFTWARE.
 		var $new = null
 		if (confirm( "Are you sure you want to rename: " + originalName + " to " + newName + '?' )) {
 
-		    solFiles[solFiles.indexOf(originalName)] = newName
+		    solFiles.splice( solFiles.indexOf(originalName), 1, newName );
 		    window.localStorage.setItem( newName, window.localStorage.getItem(originalName) );
 		    window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
-		    window.localStorage.setItem( originalName, '')
+		    window.localStorage.removeItem( originalName )
 		    SOL_CACHE_FILE = newName;
 		    updateFiles()
 		}
@@ -154,12 +153,11 @@ THE SOFTWARE.
 	    var name = $(this).parent().find('.name').text()
 
 	    if (confirm( "Are you sure you want to remove: " + name + " from local storage?" )) {
-		console.log("remove file, ", ev.target)
 		var index = solFiles.indexOf(name);
-		solFiles[index] = undefined;
+		solFiles.splice(index, 1 );
 		window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
 		SOL_CACHE_FILE = solFiles[ Math.max(0, index - 1)]
-		window.localStorage.setItem( name, null)
+		window.localStorage.removeItem( name )
 		updateFiles()
 	    }
 	    return false;
@@ -168,7 +166,6 @@ THE SOFTWARE.
 	function showFileHandler (ev) {
 	    ev.preventDefault()
 	    SOL_CACHE_FILE = $(this).find('.name').text();
-	    console.log('click normal', SOL_CACHE_FILE, typeof window.localStorage.getItem( SOL_CACHE_FILE ))
 	    updateFiles()
 	    return false;
 	}
@@ -178,7 +175,6 @@ THE SOFTWARE.
 	}
 
 	function updateFiles () {
-	    console.log("Update files", solFiles, SOL_CACHE_FILE, typeof window.localStorage.getItem( SOL_CACHE_FILE ) )
 	    $filesEl.find('.file').remove()
 	    for (var f in solFiles) {
 		if (solFiles[f]) $filesEl.append( fileTabTemplate(solFiles[f]) );

--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@ THE SOFTWARE.
 
 	$filesEl.on( 'click','.newFile', function(){
 	    count++;
-	    var name = 'Unititled'+count+'.sol';
+	    var name = 'Unititled'+count;
 	    solFiles.push( name )
 	    SOL_CACHE_FILE = name;
 	    window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
@@ -132,17 +132,16 @@ THE SOFTWARE.
 		ev.preventDefault()
 		var newName = ev.target.value;
 		var $new = null
-		if (confirm( "Are you sure you want to rename: " + originalName + " to " + newName + '?' )) {
+		if ( newName !== originalName && confirm( "Are you sure you want to rename: " + originalName + " to " + newName + '?' )) {
 
 		    solFiles.splice( solFiles.indexOf(originalName), 1, newName );
 		    window.localStorage.setItem( newName, window.localStorage.getItem(originalName) );
 		    window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
 		    window.localStorage.removeItem( originalName )
 		    SOL_CACHE_FILE = newName;
-		    updateFiles()
 		}
 
-		fileTabFromName(newName || originalName ).addClass('active')
+		updateFiles()
 		return false;
 	    })
 	    return false;

--- a/index.html
+++ b/index.html
@@ -86,16 +86,27 @@ THE SOFTWARE.
 	var SOL_CACHE_FILES_KEY = "sol-cache-files";
 
 	var editor = ace.edit("input");
-		var session = editor.getSession();
-		var Range = ace.require('ace/range').Range;
+	var session = editor.getSession();
+	var Range = ace.require('ace/range').Range;
 	var errMarkerId = null;
 
 	var solFiles = JSON.parse( window.localStorage.getItem( SOL_CACHE_FILES_KEY ) ) || [SOL_CACHE_FILE];
 	if (solFiles.length === 0) solFiles = [SOL_CACHE_FILE];
-	window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
-
 	var solCache = window.localStorage.getItem( SOL_CACHE_FILE ) || BALLOT_EXAMPLE;
 	window.localStorage.setItem( SOL_CACHE_FILE, solCache )
+
+	if (window.localStorage.getItem('sol-cache')) {
+		// Backwards-compatibility
+		var count = '';
+		while (window.localStorage.getItem('Untitled' + count))
+			count = (count - 0) + 1;
+		window.localStorage.setItem('Untitled' + count, window.localStorage.getItem('sol-cache'));
+		window.localStorage.removeItem('sol-cache');
+		solFiles.push('Untitled' + count);
+	}
+
+	window.localStorage.setItem( SOL_CACHE_FILES_KEY, JSON.stringify( solFiles ) );
+
 	editor.setValue( solCache, 1 );
 
 

--- a/index.html
+++ b/index.html
@@ -286,15 +286,19 @@ THE SOFTWARE.
 		var previousInput = '';
 		var sourceAnnotations = [];
 		var compile = function() {
+
 			editor.getSession().clearAnnotations();
 			sourceAnnotations = [];
 			editor.getSession().removeMarker(errMarkerId);
-		$('#output').empty();
-		var input = editor.getValue();
-		var inputIncludingImports = includeLocalImports( input );
-		var optimize = document.querySelector('#optimize').checked;
-		try {
-		var data = $.parseJSON(compileJSON(inputIncludingImports, optimize ? 1 : 0));
+			$('#output').empty();
+			var input = editor.getValue();
+			window.localStorage.setItem( SOL_CACHE_FILE, input );
+
+			var inputIncludingImports = includeLocalImports( input );
+			var optimize = document.querySelector('#optimize').checked;
+			
+			try {
+				var data = $.parseJSON(compileJSON(inputIncludingImports, optimize ? 1 : 0));
 			} catch (exception) {
 				renderError("Uncaught JavaScript Exception:\n" + exception);
 				return;
@@ -309,11 +313,12 @@ THE SOFTWARE.
 				renderContracts(data, input);
 				
 		}
+		
 		var compileTimeout = null;
 		var onChange = function() {
 			var input = editor.getValue();
 			if (input === "") {
-		window.localStorage.setItem( SOL_CACHE_FILE, '' )
+				window.localStorage.setItem( SOL_CACHE_FILE, '' )
 				return;
 			}
 			if (input === previousInput)
@@ -411,8 +416,6 @@ THE SOFTWARE.
 		};
 
 		var renderContracts = function(data, source) {
-		window.localStorage.setItem( SOL_CACHE_FILE, source );
-
 			$('#output').empty();
 			for (var contractName in data.contracts) {
 				var contract = data.contracts[contractName];

--- a/index.html
+++ b/index.html
@@ -161,8 +161,8 @@ THE SOFTWARE.
 		var index = getFiles().indexOf( fileKey(name) );
 
 		if (confirm("Are you sure you want to remove: " + name + " from local storage?")) {
-			SOL_CACHE_FILE = getFiles()[ Math.max(0, index - 1)];
 			window.localStorage.removeItem( fileKey( name ) );
+			SOL_CACHE_FILE = getFiles()[ Math.max(0, index - 1)];
 			updateFiles();
 		}
 		return false;
@@ -187,10 +187,16 @@ THE SOFTWARE.
 		for (var f in files) {
 			$filesEl.append(fileTabTemplate(files[f]));
 		}
-		var active = fileTabFromKey(SOL_CACHE_FILE);
-		active.addClass('active');
-		editor.setValue( window.localStorage[SOL_CACHE_FILE] || '', -1);
-		$('#input').toggle( true );
+		
+		if (SOL_CACHE_FILE) {
+			var active = fileTabFromKey(SOL_CACHE_FILE);
+			active.addClass('active');
+			editor.setValue( window.localStorage[SOL_CACHE_FILE] || '', -1);
+			editor.focus();
+			$('#input').toggle( true );
+		} else {
+			$('#input').toggle( false );
+		}
 	}
 
 	function fileTabTemplate(key) {

--- a/stylesheets/browser-solidity.css
+++ b/stylesheets/browser-solidity.css
@@ -10,12 +10,69 @@ body {
     width: auto;
     bottom: 0px;
     right: 37em;
-    
 }
+
+#files {
+    font-size: 15px;
+    height: 2.5em;
+    box-sizing: border-box;
+    line-height: 2em;
+    padding: 0.5em 0.5em 0;
+}
+
+#files .file,
+#files .newFile {
+    display: inline-block;
+    padding: 0 0.6em;
+    box-sizing: border-box;
+    background-color: #f0f0f0;
+    cursor: pointer;
+    margin-right: 0.5em;
+    position: relative;
+}
+
+#files .newFile {
+    background-color: #B1EAC5;
+    font-weight: bold;
+    color: #4E775D;
+}
+
+#files .file.active {
+    font-weight: bold;
+    background-color: #F0F0F0;
+    border: 1px solid #BFBFBF;
+    box-shadow: 0 0 5px rgba(0,0,0,0.25);
+    border-bottom: 0 none;
+    padding-right: 2.5em;
+}
+#files .file .remove {
+    position: absolute;
+    right: 0;
+    top: 0;
+    height: 1.25em;
+    width: 1.25em;
+    line-height: 1em;
+    border-radius: 1em;
+    color: #FF8080;
+    display: none;
+    margin: 0.4em;
+    text-align: center;
+}
+
+#files .file input {
+    background-color: transparent;
+    border: 0 none;
+    border-bottom: 1px dotted black;
+    line-height: 1em;
+    margin: 0.5em 0;
+}
+
+#files .file.active .remove { display: inline-block; }
+
 #input {
     font-size: 15px;
     position: absolute;
-    top: 0;
+    top: 2.5em;
     left: 0;
     right: 0;
     bottom: 0;

--- a/stylesheets/browser-solidity.css
+++ b/stylesheets/browser-solidity.css
@@ -39,9 +39,6 @@ body {
 
 #files .file.active {
     font-weight: bold;
-    background-color: #F0F0F0;
-    border: 1px solid #BFBFBF;
-    box-shadow: 0 0 5px rgba(0,0,0,0.25);
     border-bottom: 0 none;
     padding-right: 2.5em;
 }


### PR DESCRIPTION
- add, rename, delete multitple local files
- allow imports for local files
- allow recusive imports `a` imports `b` imports `c` etc
- ~~[dont merge] show usage in example~~

Check it out here: http://d11e9.github.io/browser-solidity/ in ~~example solidty fails to import "test" until you add a file named "test"~~.

Updated to include changes proposed and contributed by @chriseth:
- backwards compatibility
- improved file storage scheme `localStorage[key]`
- focus editor on tab change
