### PR TITLE
npm ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+stylesheets
+libs
+solidity.svg
+ballot.sol.js
+index.html
+soljson.js
+bin/list.*
+bin/soljson-v*


### PR DESCRIPTION
add `.npmignore` to remove unnecessary files from package install.
This only omits the listed files from being downloaded when performing `npm install solc` which itself is versioned.
