### PR TITLE
Legacy npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ Starting from version 0.1.6, multiple files are supported with automatic import 
 		console.log(contractName + ': ' + output.contracts[contractName].bytecode);
 
 Note that all input files that are imported have to be supplied, the compiler will not load any additional files on its own.
+
+###Using a legacy version
+
+In order to allow compiling contracts using a specific version of solidity, the `solc.setVersion` method is available.
+
+	var solc = require('solc');
+	solc.setVersion( 'latest' ); // this is used by default
+	solc.setVersion( 'v0.1.1-2015-08-04-6ff4cd6' );
+	var output = solc.compile( "contract t { function g() {} }", 1 );

--- a/README.md
+++ b/README.md
@@ -32,9 +32,12 @@ Note that all input files that are imported have to be supplied, the compiler wi
 
 ###Using a legacy version
 
-In order to allow compiling contracts using a specific version of solidity, the `solc.setVersion` method is available.
+In order to allow compiling contracts using a specific version of solidity, the `solc.useVersion` method is available. this returns a new solc object using the version provided. **Note**: version strings must match the version substring of the files availble in `/bin/soljson-*.js`. See below for an example.
 
 	var solc = require('solc');
-	solc.setVersion( 'latest' ); // this is used by default
-	solc.setVersion( 'v0.1.1-2015-08-04-6ff4cd6' );
-	var output = solc.compile( "contract t { function g() {} }", 1 );
+	// by default the latest version is used
+	// ie: solc.useVersion('latest')
+
+	// getting a legacy version
+	var solcV011 = solc.useVersion( 'v0.1.1-2015-08-04-6ff4cd6' );
+	var output = solcV011.compile( "contract t { function g() {} }", 1 );

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Note that all input files that are imported have to be supplied, the compiler wi
 
 ###Using a legacy version
 
-In order to allow compiling contracts using a specific version of solidity, the `solc.useVersion` method is available. this returns a new solc object using the version provided. **Note**: version strings must match the version substring of the files availble in `/bin/soljson-*.js`. See below for an example.
+In order to allow compiling contracts using a specific version of solidity, the `solc.useVersion` method is available. This returns a new solc object using the version provided. **Note**: version strings must match the version substring of the files availble in `/bin/soljson-*.js`. See below for an example.
 
 	var solc = require('solc');
 	// by default the latest version is used

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 function setupMethods (soljson){
 
 	var compileJSON = soljson.cwrap("compileJSON", "string", ["string", "number"]);

--- a/index.js
+++ b/index.js
@@ -1,23 +1,30 @@
 
-var soljson = require('./bin/soljson-latest.js');
+function setupMethods (soljson){
 
-var compileJSON = soljson.cwrap("compileJSON", "string", ["string", "number"]);
-var compileJSONMulti =
-	'_compileJSONMulti' in soljson ?
-	soljson.cwrap("compileJSONMulti", "string", ["string", "number"]) :
-	null;
+	var compileJSON = soljson.cwrap("compileJSON", "string", ["string", "number"]);
+	var compileJSONMulti =
+		'_compileJSONMulti' in soljson ?
+		soljson.cwrap("compileJSONMulti", "string", ["string", "number"]) :
+		null;
 
-var compile = function(input, optimise) {
-	var result = '';
-	if (typeof(input) != typeof('') && compileJSONMulti !== null)
-		result = compileJSONMulti(JSON.stringify(input), optimise);
-	else
-		result = compileJSON(input, optimise);
-	return JSON.parse(result);
+	var compile = function(input, optimise) {
+		var result = '';
+		if (typeof(input) != typeof('') && compileJSONMulti !== null)
+			result = compileJSONMulti(JSON.stringify(input), optimise);
+		else
+			result = compileJSON(input, optimise);
+		return JSON.parse(result);
+	}
+
+	var version = soljson.cwrap("version", "string", []);
+
+	return {
+		version: version,
+		compile: compile,
+		useVersion: function( versionString ){
+			return setupMethods( require('./bin/soljson-' + versionString + '.js' ) );
+		}
+	}
 }
 
-
-module.exports = {
-	compile: compile,
-	version: soljson.cwrap("version", "string", [])
-}
+module.exports = setupMethods( require('./bin/soljson-latest.js') );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solc",
-  "version": "0.1.6",
+  "version": "0.1.6-1",
   "description": "Solidity compiler",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solc",
-  "version": "0.1.6-1",
+  "version": "0.1.6-2",
   "description": "Solidity compiler",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Allow using legacy versions of the compiler. How to included in README
