### PR TITLE
Load compiler from different repository.

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -559,13 +559,13 @@
 					// "Uncaught RangeError: Maximum call stack size exceeded" error on Chromium,
 					// resort to non-worker version in that case.
 					initializeWorker();
-					worker.postMessage({cmd: 'loadVersion', data: 'bin/' + version});
+					worker.postMessage({cmd: 'loadVersion', data: 'https://github.com/ethereum/solc-bin/raw/master/bin/' + version});
 				} else {
 					Module = null;
 					compileJSON = function(source, optimize) { compilationFinished('{}'); };
 					var newScript = document.createElement('script');
 					newScript.type = 'text/javascript';
-					newScript.src = 'bin/' + version;
+					newScript.src = 'https://github.com/ethereum/solc-bin/raw/master/bin/' + version;
 					document.getElementsByTagName("head")[0].appendChild(newScript);
 					var check = window.setInterval(function() {
 						if (!Module) return;

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
 		<link rel="stylesheet" href="assets/css/font-awesome.min.css">
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
 
-		<script src="bin/list.js"></script>
+		<script src="https://github.com/ethereum/solc-bin/raw/master/bin/list.js"></script>
 		<script src="assets/js/jquery-2.1.3.min.js"></script>
 		<script src="assets/js/ace.js"></script>
 		<script src="assets/js/mode-solidity.js"></script>


### PR DESCRIPTION
This change is in preparation to splitting off the binaries from the repository (and actually moving to a different repository). The main drawback is that this prevents offline use of browser-solidity. At some point, we will create a proper package for that.

Connects to https://github.com/chriseth/browser-solidity/issues/116
